### PR TITLE
Fix error due to `_R_CHECK_LENGTH_1_LOGIC2_`

### DIFF
--- a/R/CorrelationMethods.R
+++ b/R/CorrelationMethods.R
@@ -414,9 +414,9 @@ pairs.DataFrame <- function (x, labels, panel = points, ..., horInd = 1:nc, verI
     nc <- ncol(x)
     if (nc < 2L) 
         stop("only one column in the argument to 'pairs'")
-    if (!all(horInd >= 1L && horInd <= nc)) 
+    if (!all(horInd >= 1L & horInd <= nc)) 
         stop("invalid argument 'horInd'")
-    if (!all(verInd >= 1L && verInd <= nc)) 
+    if (!all(verInd >= 1L & verInd <= nc)) 
         stop("invalid argument 'verInd'")
     if (doText) {
         if (missing(labels)) {


### PR DESCRIPTION
This due to an inadvertent usage of `&&` for vector comparison instead of scalar comparison even with all(). See https://stat.ethz.ch/pipermail/bioc-devel/2020-January/016081.html