### PR TITLE
Promoter shifting for CAGEexp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,6 +84,6 @@ Collate:
     'StrandInvaders.R'
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/ShiftingFunctions.R
+++ b/R/ShiftingFunctions.R
@@ -35,7 +35,11 @@
 
 #####
 # Function that calculates total tag count in CAGE clusters
-# ARGUMENTS: ctss.df - data frame with one row per CTSS containing at least four columns, *chr (chromosome) *pos (genomic position of CTSSs) *strand (genomic strand) *tagcount (raw CAGE tag count)
+# ARGUMENTS: ctss.df - data frame with one row per CTSS containing at least four columns, 
+# *chr (chromosome) 
+# *pos (genomic position of CTSSs) 
+# *strand (genomic strand) 
+# *tagcount (raw CAGE tag count)
 #            ctss.clusters - data frame with one row per cluster containing at least 6 columns, *cluster (cluster ID) *chr (chromosome) *start (start position of the cluster) *end (end position of the cluster) *strand (strand) *dominant_ctss (position of dominant peak)
 # RETURNS: integer vector of total tag count per cluster 
 
@@ -46,12 +50,15 @@ setGeneric( ".getTotalTagCount"
 
 setMethod( ".getTotalTagCount", "CTSS"
          , function(ctss, ctss.clusters) {
-	o <- findOverlaps(ctss.clusters, ctss)
+	
+  o <- findOverlaps(ctss.clusters, ctss)
 	totalCount <- tapply( decode(score(ctss)[subjectHits(o)])
-	                    , ctss.clusters$consensus.cluster[queryHits(o)]
+	                    , queryHits(o)
 	                    , sum)
+	
 	ctss.clusters$total <- 0
-	mcols(ctss.clusters)[as.numeric(names(totalCount)),"total"] <- totalCount
+	mcols(ctss.clusters)[as.numeric(names(totalCount)),"total"] <-  
+	                          totalCount
 	ctss.clusters$total
 })
 

--- a/R/ShiftingMethods.R
+++ b/R/ShiftingMethods.R
@@ -286,9 +286,10 @@ setMethod( "scoreShift", "CAGEexp"
   			tag.count.m.new <- cbind(groupX = rowSums(tag.count.m[,groupX,drop=F]), 
   			                        groupY = rowSums(tag.count.m[,groupY,drop=F]))
   			n <- (tag.count.m.new[,"groupX"] * tag.count.m.new[,"groupY"])/(tag.count.m.new[,"groupX"] + tag.count.m.new[,"groupY"])
-  			
+  			names(n) <- names(cumsum.matrices.groups.f)
 		}
 		
+	  
 		ks.stat <- unlist(bplapply(cumsum.matrices.groups.f, function(x) {ks.s <- .ksStat(x)}, BPPARAM = CAGEr_Multicore(useMulticore, nrCores)))
 		
 		p.vals <- .ksPvalue(d = ks.stat, n = n[names(cumsum.matrices.groups.f)])
@@ -418,18 +419,20 @@ setMethod( "getShiftingPromoters", "CAGEexp"
 	## find which columns are relevant?
 	sig.shifting <- 
 	  shifting.scores[ ( shifting.scores[, gXtpm_cname] >= tpmThreshold &
-	                     shifting.scores[, gYtpm_cname] >= tpmThreshold) &
-	                     !is.na(shifting.scores[, shiftSc_cname])
+	                     shifting.scores[, gYtpm_cname] >= tpmThreshold &
+	                     !is.na(shifting.scores[, shiftSc_cname]))
 	                                , sel_cnames]
 
 	## leave-out where score is NA
 	sig.shifting <- sig.shifting[sig.shifting[, shiftSc_cname] >= scoreThreshold, ]
 	
 	## 
-	
-	
+
 	if(fdr_cname %in% colnames(shifting.scores)){
+	  sig.shifting <- sig.shifting[
+	                      !is.na(sig.shifting[, fdr_cname]), sel_cnames] 
 		sig.shifting <- sig.shifting[sig.shifting[, fdr_cname] <= fdrThreshold,]
+		
 	}
 	
 	## This merging may no longer be needed

--- a/R/ShiftingMethods.R
+++ b/R/ShiftingMethods.R
@@ -342,6 +342,10 @@ setMethod( "scoreShift", "CAGEexp"
 #' 
 #' @param object A \code{\link{CAGEexp}} object.
 #' 
+#' @param groupX,groupY Character vector of the one or more CAGE dataset labels in the first
+#' (\code{groupX}) and in the second group (\code{groupY}). Shifting promoters for the specified 
+#' group pair are returned. 
+#' 
 #' @param tpmThreshold Consensus clusters with total CAGE signal \code{>= tpmThreshold}
 #'        in each of the compared groups will be returned.
 #' 

--- a/man/getShiftingPromoters.Rd
+++ b/man/getShiftingPromoters.Rd
@@ -7,6 +7,8 @@
 \usage{
 getShiftingPromoters(
   object,
+  groupX,
+  groupY,
   tpmThreshold = 0,
   scoreThreshold = -Inf,
   fdrThreshold = 1
@@ -14,6 +16,8 @@ getShiftingPromoters(
 
 \S4method{getShiftingPromoters}{CAGEexp}(
   object,
+  groupX,
+  groupY,
   tpmThreshold = 0,
   scoreThreshold = -Inf,
   fdrThreshold = 1
@@ -22,13 +26,17 @@ getShiftingPromoters(
 \arguments{
 \item{object}{A \code{\link{CAGEexp}} object.}
 
+\item{groupX, groupY}{Character vector of the one or more CAGE dataset labels in the first
+(\code{groupX}) and in the second group (\code{groupY}). Shifting promoters for the specified
+group pair are returned.}
+
 \item{tpmThreshold}{Consensus clusters with total CAGE signal \code{>= tpmThreshold}
 in each of the compared groups will be returned.}
 
 \item{scoreThreshold}{Consensus clusters with shifting score \code{>= scoreThreshold}
 will be returned. The default value \code{-Inf} returns all consensus clusters
 (for which score could be calculated, \emph{i.e.} the ones that have at least
-one tag in each of the comapred samples).}
+one tag in each of the compared samples).}
 
 \item{fdrThreshold}{Consensus clusters with adjusted P-value (FDR) from
 Kolmogorov-Smirnov test \code{>= fdrThreshold} will be returned. The default
@@ -59,5 +67,7 @@ Other CAGEr promoter shift functions:
 }
 \author{
 Vanja Haberle
+
+Sarvesh Nikumbh
 }
 \concept{CAGEr promoter shift functions}

--- a/man/scoreShift.Rd
+++ b/man/scoreShift.Rd
@@ -123,5 +123,7 @@ Other CAGEr promoter shift functions:
 }
 \author{
 Vanja Haberle
+
+Sarvesh Nikumbh
 }
 \concept{CAGEr promoter shift functions}

--- a/vignettes/CAGEexp.Rmd
+++ b/vignettes/CAGEexp.Rmd
@@ -797,7 +797,7 @@ ECDFs.  These are derived either from raw tag counts, _i.e._ exact number of
 times each TSS in the cluster was sampled during sequencing (when
 `useTpmKS = FALSE`), or from normalized tpm values (when `useTpmKS = TRUE`).
 P-values obtained from K-S tests are further corrected for multiple testing
-using Benjamini and Hochenberg (BH) method and for each P-value a corresponding
+using Benjamini and Hochberg (BH) method and for each P-value a corresponding
 false-discovery rate (FDR) is also reported.
 
 ```{r ShiftingScore, echo=FALSE, fig.cap="Calculation of shifting score"}

--- a/vignettes/CAGEexp.Rmd
+++ b/vignettes/CAGEexp.Rmd
@@ -157,7 +157,8 @@ methods.  The expression data is stored in _CAGEexp_ using
 To load the _CAGEr_ package and the other libraries into your R envirnoment type:
 
 ```{r load_CAGEr}
-library(CAGEr)
+# library(CAGEr)
+devtools::load_all()
 ```
 
 Creating a _CAGEexp_ object {#create-CAGEexp}
@@ -765,8 +766,8 @@ all promoters comparing two specified samples:
 
 ```{r}
 # Not supported yet for CAGEexp objects, sorry.
-# scoreShift(ce, groupX = "Zf.unfertilized.egg", groupY = "zf_prim6",
-# 		testKS = TRUE, useTpmKS = FALSE)
+ce <- scoreShift(ce, groupX = "Zf.unfertilized.egg", groupY = "Zf.prim6",
+		testKS = TRUE, useTpmKS = FALSE)
 ```
 
 This function will calculate shifting score as illustrated in
@@ -807,10 +808,11 @@ We can select a subset of promoters with shifting score and/or FDR above specifi
 
 ```{r}
 # Not supported yet for CAGEexp objects, sorry.
-# shifting.promoters <- getShiftingPromoters(ce, 
-# 		tpmThreshold = 5, scoreThreshold = 0.6,
-# 		fdrThreshold = 0.01)
-# head(shifting.promoters)
+shifting.promoters <- getShiftingPromoters(ce, 
+    groupX = "Zf.unfertilized.egg", groupY = "Zf.prim6",
+		tpmThreshold = 5, scoreThreshold = 0.6,
+		fdrThreshold = 0.01)
+head(shifting.promoters)
 ```
 
 The `getShiftingPromoters` function returns genomic coordinates, shifting score


### PR DESCRIPTION
Hi Charles,
I think this is now ready for you to review. 
I have made changes to the source code and also minor changes to man pages, and vignette.
Importantly, I added this new capability:
-- scoreShift updates the rowData of consensusClusters every time is called with the corresponding new columns (shifting.score, pos and tpm). The names of these new columns include the groupX and groupY details. This way when scoreShift is called multiple times with different group pairs, all of it is saved.
-- new arguments to getShiftingPromoters (groupX and groupY) to extract relevant info from the rowData (because it now have multiple shifting.scores for different group pairs 

I added this because it should not be needed to call scoreShift multiple times with different group pairs. If you think this will be confusing, I can change this behaviour.