### PR TITLE
fixing score import

### DIFF
--- a/R/ImportMethods.R
+++ b/R/ImportMethods.R
@@ -530,9 +530,13 @@ import.bigwig <- function(filepath){
     if(!file.exists(str2_path)) stop("File ", str2_path, " does not exist!")
     plus <- import.bw(filepath)
     strand(plus) <- '+'
+    gpp <- GPos(plus, stitch=FALSE)
+    score(gpp) <- plus$score
     minus <- import.bw(str2_path) 
     strand(minus) <- '-'
-    GPos(c(plus, minus), stitch=FALSE)
+    gpn <- GPos(minus, stitch=FALSE)
+    score(gpn) <- minus$score
+    c(gpp, gpn)
 }
 
 #' parseCAGEscanBlocksToGrangeTSS


### PR DESCRIPTION
Hi again,

I retested this on a VM with clean installation and all, and turns out the score needs to be transferred here otherwise it throws and error later at getCTSS().
I ran everything with Danio rerio bsgenome, and it goes through so I think we can keep this dataset with that genome.
The rtracklayer import is a mistery.